### PR TITLE
Publish to IPNS every 12 hours

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          ipfs name publish --key=IPNSKey /ipfs/${{ needs.publish_ipfs.outputs.cid }}
+          ipfs name publish --lifetime 168h --key=IPNSKey /ipfs/${{ needs.publish_ipfs.outputs.cid }}
       - name: Sleep for 10s
         uses: juliangruber/sleep-action@v1
         with:

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          ipfs name publish --key=IPNSKey /ipfs/${{ needs.publish_ipfs.outputs.cid }}
+          ipfs name publish --lifetime 168h --key=IPNSKey /ipfs/${{ needs.publish_ipfs.outputs.cid }}
       - name: Sleep for 10s
         uses: juliangruber/sleep-action@v1
         with:


### PR DESCRIPTION
Publish to IPNS every 12 hours to prevent nodes forgetting configuration.

Closes: #10 