### PR TITLE
feat: add fee router address

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -28,6 +28,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 7225328,
+      "feeRouter": "0x6CAf9103c8cE3c9C347D57Aee39E8e66e43091b8",
       "feeHandlers": [
         {
           "address": "0x81bbFC4aC5E731d9EAdb749a7e7A6E973CF7E399",
@@ -97,6 +98,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 27171235,
+      "feeRouter": "0x2F14a0Ffc2FE72E55e18b0f04De2582237065a51",
       "feeHandlers": [
         {
           "address": "0x2fD80b28DbA645A23d8Fb83EC428468a95F0Aa7a",
@@ -166,6 +168,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 2916751,
+      "feeRouter": "0x787dce8aA901E0bAF1CD191b8B4695B6dd4dcf89",
       "feeHandlers": [
         {
           "address": "0x2AF8df30309A0c68Af6D5FD5bd5E5D2005A40fE6",
@@ -235,6 +238,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 3054823,
+      "feeRouter": "0xF9ab418D23603Ca37794eAe300F130c5d887732C",
       "feeHandlers": [
         {
           "address": "0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622",

--- a/config.test.json
+++ b/config.test.json
@@ -28,6 +28,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 8056086,
+      "feeRouter": "0xC3ea0Fbaa708D225BD2575dC4A57e0eaE8aFc77F",
       "feeHandlers": [
         {
           "address": "0x530Ca8291856c727cc6a33c2ACD50f79184AFA3d",
@@ -97,6 +98,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 3282200,
+      "feeRouter": "0x6593d8aF009d35d0BbB6eDe1dd29dF55b73F9A98",
       "feeHandlers": [
         {
           "address": "0xe7Ed7AAd072ACd23bA36F906C2515DF8eD43d482",
@@ -166,6 +168,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 29438072,
+      "feeRouter": "0x2247c836CC252F0D7D06883350e902996Ddb442D",
       "feeHandlers": [
         {
           "address": "0xe255cA458925c26d3E05004e247579A64b020cEF",
@@ -235,6 +238,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 3127956,
+      "feeRouter": "0x2247c836CC252F0D7D06883350e902996Ddb442D",
       "feeHandlers": [
         {
           "address": "0xe255cA458925c26d3E05004e247579A64b020cEF",

--- a/schema.json
+++ b/schema.json
@@ -56,6 +56,9 @@
                 }
               ]
             },
+            "feeRouter": {
+              "type": "string"
+            },
             "feeHandlers": {
               "type": "array",
               "items": [


### PR DESCRIPTION
Add fee router address to the shared configuration structure. 

This is a temporary addition to facilitate adding shared configuration support to transfer UI - [PR](https://github.com/sygmaprotocol/sygma-ui/pull/106).

On adding shared configuration support to the SDK, we will reevaluate all properties that are needed only by the UI/SDK and reduce them to ones not available from reading on-chain data.