### PR TITLE
chore: set symbol and decimals on permissionless generic resource

### DIFF
--- a/testnet/shared-config-dev.json
+++ b/testnet/shared-config-dev.json
@@ -67,8 +67,8 @@
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
           "address": "",
-          "symbol": "",
-          "decimals": 0
+          "symbol": "eth",
+          "decimals": 18
         },
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000700",
@@ -169,8 +169,8 @@
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
           "address": "",
-          "symbol": "",
-          "decimals": 0
+          "symbol": "eth",
+          "decimals": 18
         },
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000700",
@@ -271,8 +271,8 @@
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
           "address": "",
-          "symbol": "",
-          "decimals": 0
+          "symbol": "eth",
+          "decimals": 18
         },
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000700",
@@ -335,8 +335,8 @@
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
           "address": "",
-          "symbol": "",
-          "decimals": 0
+          "symbol": "eth",
+          "decimals": 18
         }
       ]
     }

--- a/testnet/shared-config-test.json
+++ b/testnet/shared-config-test.json
@@ -44,8 +44,8 @@
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
           "address": "",
-          "symbol": "",
-          "decimals": 0
+          "symbol": "eth",
+          "decimals": 18
         },
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000001000",
@@ -104,8 +104,8 @@
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
           "address": "",
-          "symbol": "",
-          "decimals": 0
+          "symbol": "eth",
+          "decimals": 18
         }
       ]
     },


### PR DESCRIPTION
## Description
Adding symbol and decimals to the generic permissionless resource because it Is necessary for fee-oracle to work properly