### PR TITLE
fix: bump start blocks to latest on testnet

### DIFF
--- a/testnet/shared-config-test.json
+++ b/testnet/shared-config-test.json
@@ -32,7 +32,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 4228380,
+      "startBlock": 5703542,
       "feeRouter": "0xCF4324adDf2ECA0181A2A0F5176ef61D115C0ae4",
       "feeHandlers": [
         {
@@ -106,7 +106,7 @@
       "nativeTokenFullName": "pha",
       "nativeTokenDecimals": 12,
       "blockConfirmations": 2,
-      "startBlock": 5888,
+      "startBlock": 853611,
       "resources": [
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000001000",
@@ -183,7 +183,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 12876313,
+      "startBlock": 20483766,
       "feeRouter": "0xA7f6f510E7d36bC52a19e8e812933F022Be9d86b",
       "feeHandlers": [
         {
@@ -257,7 +257,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 240679	,
+      "startBlock": 1351739,
       "feeRouter": "0x5626A5a7b65E3d851c693AC583068e75853fE0C8",
       "feeHandlers": [
         {
@@ -310,7 +310,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 6414771,
+      "startBlock": 33918637,
       "feeRouter": "0x723366b1Cfff44ebddCB1E1FE569a439363E3B80",
       "feeHandlers": [
         {
@@ -363,7 +363,7 @@
       "nativeTokenFullName": "xdai",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 7761223,
+      "startBlock": 9275873,
       "feeRouter": "0x3F22ae1e689561Fb36013e40b464482EFA8ec465",
       "feeHandlers": [
         {
@@ -416,7 +416,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 7501472,
+      "startBlock":  8708492,
       "feeRouter": "0x772e242e6c312f6eF6255d8F35921e7A30D018BA",
       "feeHandlers": [
         {


### PR DESCRIPTION
This is to fix the bug on the relayers where it indexed from starting block. 
After the PR on relayer is merged this will start indexing from the layers from the block set here which is latest.