### PR TITLE
feat: shared configuration upgrades

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -17,6 +17,16 @@ jobs:
         uses: nhalstead/validate-json-action@0.1.3
         with:
           schema: /schema.json
+          jsons: /testnet/shared-config-dev.json
+
+  validate-devnet-v3-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate JSON
+        uses: nhalstead/validate-json-action@0.1.3
+        with:
+          schema: /schema.json
           jsons: /testnet/shared-config-dev-v3.json
 
   validate-testnet-json:

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -9,52 +9,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate-devnet-json:
+  validate-json:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - name: validate-devnet-json
+            schema: /schema.json
+            json: /testnet/shared-config-dev.json
+          - name: validate-devnet-v3-json
+            schema: /schema-v3.json
+            json: /testnet/shared-config-dev-v3.json
+          - name: validate-testnet-json
+            schema: /schema.json
+            json: /testnet/shared-config-test.json
+#          - name: validate-testnet-v3-json
+#            schema: /schema-v3.json
+#            json: /testnet/shared-config-test-v3.json
+          - name: validate-mainnet-json
+            schema: /schema.json
+            json: /mainnet/shared-config-mainnet.json
+#          - name: validate-mainnet-v3-json
+#            schema: /schema-v3.json
+#            json: /mainnet/shared-config-mainnet-v3.json
+          - name: validate-x-json
+            schema: /schema.json
+            json: /testnet/shared-config-x.json
     steps:
       - uses: actions/checkout@v1
       - name: Validate JSON
         uses: nhalstead/validate-json-action@0.1.3
         with:
-          schema: /schema.json
-          jsons: /testnet/shared-config-dev.json
-
-  validate-devnet-v3-json:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Validate JSON
-        uses: nhalstead/validate-json-action@0.1.3
-        with:
-          schema: /schema-v3.json
-          jsons: /testnet/shared-config-dev-v3.json
-
-  validate-testnet-json:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Validate JSON
-        uses: nhalstead/validate-json-action@0.1.3
-        with:
-          schema: /schema.json
-          jsons: /testnet/shared-config-test.json
-
-  validate-mainnet-json:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Validate JSON
-        uses: nhalstead/validate-json-action@0.1.3
-        with:
-          schema: /schema.json
-          jsons: /mainnet/shared-config-mainnet.json
-
-  validate-x-json:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Validate JSON
-        uses: nhalstead/validate-json-action@0.1.3
-        with:
-          schema: /schema.json
-          jsons: /testnet/shared-config-x.json
+          schema: ${{ matrix.config.schema }}
+          jsons: ${{ matrix.config.json }}

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Validate JSON
         uses: nhalstead/validate-json-action@0.1.3
         with:
-          schema: /schema.json
+          schema: /schema-v3.json
           jsons: /testnet/shared-config-dev-v3.json
 
   validate-testnet-json:
@@ -48,6 +48,7 @@ jobs:
         with:
           schema: /schema.json
           jsons: /mainnet/shared-config-mainnet.json
+
   validate-x-json:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -17,7 +17,7 @@ jobs:
         uses: nhalstead/validate-json-action@0.1.3
         with:
           schema: /schema.json
-          jsons: /testnet/shared-config-dev.json
+          jsons: /testnet/shared-config-dev-v3.json
 
   validate-testnet-json:
     runs-on: ubuntu-latest

--- a/schema-v3.json
+++ b/schema-v3.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "domains": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "sygmaId": {
+              "type": "integer"
+            },
+            "chainId": {
+              "type": "integer"
+            },
+            "parachainId": {
+              "type": "integer"
+            },
+            "caipId": {
+              "type": "string",
+              "pattern": "^[a-z0-9]{3,8}:[a-zA-Z0-9]{1,32}$"
+            },
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "evm",
+                "substrate"
+              ]
+            },
+            "bridge": {
+              "type": "string",
+              "pattern": "^$|^0x[a-fA-F0-9]{40}$"
+            },
+            "nativeTokenSymbol": {
+              "type": "string"
+            },
+            "nativeTokenFullName": {
+              "type": "string"
+            },
+            "nativeTokenDecimals": {
+              "type": "integer"
+            },
+            "blockConfirmations": {
+              "type": "integer"
+            },
+            "startBlock": {
+              "type": "integer"
+            },
+            "handlers": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "erc20",
+                        "erc721",
+                        "permissionedGeneric",
+                        "permissionlessGeneric",
+                        "xc20"
+                      ]
+                    },
+                    "address": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "address"
+                  ]
+                }
+              ]
+            },
+            "resources": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "sygmaResourceId": {
+                      "type": "string",
+                      "pattern": "^0x[0-9]{64}$"
+                    },
+                    "caip19": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9]{3,8}:[a-zA-Z0-9]{1,32}/[a-zA-Z0-9]{3,8}:[-.%a-zA-Z0-9]{1,128}$"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "fungible",
+                        "nonfungible",
+                        "permissionedGeneric",
+                        "permissionlessGeneric"
+                      ]
+                    },
+                    "address": {
+                      "type": "string",
+                      "pattern": "^$|^0x[a-fA-F0-9]{40}$"
+                    },
+                    "symbol": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sygmaResourceId",
+                    "caip19",
+                    "type",
+                    "address",
+                    "symbol"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "sygmaId",
+            "chainId",
+            "caipId",
+            "name",
+            "type",
+            "bridge",
+            "nativeTokenSymbol",
+            "nativeTokenFullName",
+            "nativeTokenDecimals",
+            "blockConfirmations",
+            "startBlock",
+            "handlers",
+            "resources"
+          ]
+        }
+      ]
+    }
+  },
+  "required": [
+    "domains"
+  ]
+}

--- a/testnet/shared-config-dev-v3.json
+++ b/testnet/shared-config-dev-v3.json
@@ -1,31 +1,31 @@
 {
   "domains": [
     {
-      "sygmaId": 2,
+      "sygmaId": 1,
       "chainId": 11155111,
       "caipId": "eip155:11155111",
       "name": "sepolia",
       "type": "evm",
-      "bridge": "0x0903C2cBB992380450598f610101424671D2940a",
+      "bridge": "0x8c7ef673fdB8A91c70f85b7f9Cf5055C0D6B4410",
       "handlers": [
         {
           "type": "erc20",
-          "address": "0x0c824cbf76A0AaA23A6884727E798Cf5Cf247A27"
+          "address": "0x9354dD909416Be9405F174A9Fa81dD5D3F72bE5D"
         },
         {
           "type": "erc721",
-          "address": "0xA89B2cF596622d04abCf8Fd904397fF9daCEAa1E"
+          "address": "0x482BBD2DA050dB6f2f6EAa9278408A116905826F"
         },
         {
           "type": "permissionlessGeneric",
-          "address": "0x3f2186A560879cA3f13749d50F06f3f4cC271231"
+          "address": "0xD006a7c5A723476dc1b088880b2017116Ea371dc"
         }
       ],
       "nativeTokenSymbol": "eth",
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 5915176,
+      "startBlock": 5962175,
       "resources": [
         {
           "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -63,32 +63,32 @@
       ]
     },
     {
-      "sygmaId": 3,
+      "sygmaId": 2,
       "chainId": 17000,
       "caipId": "eip155:17000",
       "name": "holesky",
       "type": "evm",
-      "bridge": "0x404aDEFc0410d90b134aaf27f8c65A7dB1487663",
+      "bridge": "0x4f1624f758f43c69750f70cb12922A4ba34b6558",
       "handlers": [
         {
           "type": "erc20",
-          "address": "0xd7bF1cDc3B2695c8cE42fDc06a832dC198Ca8c6E"
+          "address": "0x26cB44fa6a2F8Abbb4BA1cAcD9b2A46d80c4d8cC"
         },
         {
           "type": "erc721",
-          "address": "0x5266f231ac9eB0A701852b03Eb4dac9416B64064"
+          "address": "0x5e1ff3a04FF54c6B841393306e1a57ED44Ae8005"
         },
 
         {
           "type": "permissionlessGeneric",
-          "address": "0xb82d24e7738451824564a206BF897A8B09480841"
+          "address": "0x675F2F8B8b67149BDac736c1AbD561Ee450a08D5"
         }
       ],
       "nativeTokenSymbol": "eth",
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock": 1555707,
+      "startBlock": 1597715,
       "resources": [
         {
           "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/testnet/shared-config-dev-v3.json
+++ b/testnet/shared-config-dev-v3.json
@@ -1,8 +1,9 @@
 {
   "domains": [
     {
-      "id": 2,
+      "sygmaId": 2,
       "chainId": 11155111,
+      "caipId": "eip155:11155111",
       "name": "sepolia",
       "type": "evm",
       "bridge": "0x0903C2cBB992380450598f610101424671D2940a",
@@ -25,24 +26,10 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 5915176,
-      "feeRouter": "0xE119B7736fC3e5E53C828d8708d64364CA7eF4B7",
-      "feeHandlers": [
-        {
-          "address": "0x0302B3056905B941CC82974D22F615CA90fF4b78",
-          "type": "basic"
-        },
-        {
-          "address": "0x168696d55a73DF66DAA340f612a83e425BeF4f74",
-          "type": "percentage"
-        },
-        {
-          "address": "0xc62Eaab9FaBB603A7D4eFDc9e75956e7929b17D9",
-          "type": "twap"
-        }
-      ],
       "resources": [
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "caip19": "eip155:11155111/erc20:0xFD0421E981542707869Db272ae98c1C8C98448C2",
           "type": "fungible",
           "address": "0xFD0421E981542707869Db272ae98c1C8C98448C2",
           "burnable": true,
@@ -50,21 +37,24 @@
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
+          "caip19": "eip155:11155111/erc20:0x6D3E32d5b6818A274F00fE69e33b54b4a820CD60",
           "type": "fungible",
           "address": "0x6D3E32d5b6818A274F00fE69e33b54b4a820CD60",
           "symbol": "ERC20LRTest",
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
+          "caip19": "eip155:11155111/erc20:0xb8b43e03cba3Ab1f5799E5525E124d700924163f",
           "type": "nonfungible",
           "address": "0xb8b43e03cba3Ab1f5799E5525E124d700924163f",
           "symbol": "ERC721TST",
           "decimals": 0
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
+          "caip19": "",
           "type": "permissionlessGeneric",
           "address": "",
           "symbol": "eth",
@@ -73,8 +63,9 @@
       ]
     },
     {
-      "id": 3,
+      "sygmaId": 3,
       "chainId": 17000,
+      "caipId": "eip155:17000",
       "name": "holesky",
       "type": "evm",
       "bridge": "0x404aDEFc0410d90b134aaf27f8c65A7dB1487663",
@@ -98,47 +89,36 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 1555707,
-      "feeRouter": "0x51A8a164614DFBA8508eB384eEC01259af811595",
-      "feeHandlers": [
-        {
-          "address": "0xFf561FF3bCb12b1aa208E0E216e3C0B9bE7c3392",
-          "type": "basic"
-        },
-        {
-          "address": "0xf64cE3a1c66E1d3a86Dcf32b074f0E58F13e2f3B",
-          "type": "percentage"
-        },
-        {
-          "address": "0xEbBF01ff875d8C8F6f284E5838d9605c92D90a75",
-          "type": "twap"
-        }
-      ],
       "resources": [
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "type": "fungible",
+          "caip19": "eip155:17000/erc20:0x873Ce69Da09b380d6531aBaD3A86A16950e01Fc8",
           "address": "0x873Ce69Da09b380d6531aBaD3A86A16950e01Fc8",
           "burnable": true,
           "symbol": "ERC20TST",
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
           "type": "fungible",
+          "caip19": "eip155:17000/erc20:0xDDf81Bd7c08ad69D4ed82A2c2E190c65D30cc8bA",
           "address": "0xDDf81Bd7c08ad69D4ed82A2c2E190c65D30cc8bA",
           "symbol": "ERC20LRTest",
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
           "type": "nonfungible",
+          "caip19": "eip155:17000/erc20:0xF8550C42Cbe8040D471cEFAA80f4Eded6Cfb34Ab",
           "address": "0xF8550C42Cbe8040D471cEFAA80f4Eded6Cfb34Ab",
           "symbol": "ERC721TST",
           "decimals": 0
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
+          "caip19": "",
           "address": "",
           "symbol": "eth",
           "decimals": 18

--- a/testnet/shared-config-dev.json
+++ b/testnet/shared-config-dev.json
@@ -26,21 +26,6 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 5915176,
-      "feeRouter": "0xE119B7736fC3e5E53C828d8708d64364CA7eF4B7",
-      "feeHandlers": [
-        {
-          "address": "0x0302B3056905B941CC82974D22F615CA90fF4b78",
-          "type": "basic"
-        },
-        {
-          "address": "0x168696d55a73DF66DAA340f612a83e425BeF4f74",
-          "type": "percentage"
-        },
-        {
-          "address": "0xc62Eaab9FaBB603A7D4eFDc9e75956e7929b17D9",
-          "type": "twap"
-        }
-      ],
       "resources": [
         {
           "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -104,21 +89,6 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "startBlock": 1555707,
-      "feeRouter": "0x51A8a164614DFBA8508eB384eEC01259af811595",
-      "feeHandlers": [
-        {
-          "address": "0xFf561FF3bCb12b1aa208E0E216e3C0B9bE7c3392",
-          "type": "basic"
-        },
-        {
-          "address": "0xf64cE3a1c66E1d3a86Dcf32b074f0E58F13e2f3B",
-          "type": "percentage"
-        },
-        {
-          "address": "0xEbBF01ff875d8C8F6f284E5838d9605c92D90a75",
-          "type": "twap"
-        }
-      ],
       "resources": [
         {
           "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/testnet/shared-config-dev.json
+++ b/testnet/shared-config-dev.json
@@ -1,8 +1,9 @@
 {
   "domains": [
     {
-      "id": 2,
+      "sygmaId": 2,
       "chainId": 11155111,
+      "caipId": "eip155:11155111",
       "name": "sepolia",
       "type": "evm",
       "bridge": "0x0903C2cBB992380450598f610101424671D2940a",
@@ -42,7 +43,8 @@
       ],
       "resources": [
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "caip19": "eip155:11155111/erc20:0xFD0421E981542707869Db272ae98c1C8C98448C2",
           "type": "fungible",
           "address": "0xFD0421E981542707869Db272ae98c1C8C98448C2",
           "burnable": true,
@@ -50,21 +52,24 @@
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
+          "caip19": "eip155:11155111/erc20:0x6D3E32d5b6818A274F00fE69e33b54b4a820CD60",
           "type": "fungible",
           "address": "0x6D3E32d5b6818A274F00fE69e33b54b4a820CD60",
           "symbol": "ERC20LRTest",
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
+          "caip19": "eip155:11155111/erc20:0xb8b43e03cba3Ab1f5799E5525E124d700924163f",
           "type": "nonfungible",
           "address": "0xb8b43e03cba3Ab1f5799E5525E124d700924163f",
           "symbol": "ERC721TST",
           "decimals": 0
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
+          "caip19": "",
           "type": "permissionlessGeneric",
           "address": "",
           "symbol": "eth",
@@ -73,8 +78,9 @@
       ]
     },
     {
-      "id": 3,
+      "sygmaId": 3,
       "chainId": 17000,
+      "caipId": "eip155:17000",
       "name": "holesky",
       "type": "evm",
       "bridge": "0x404aDEFc0410d90b134aaf27f8c65A7dB1487663",
@@ -115,30 +121,34 @@
       ],
       "resources": [
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "type": "fungible",
+          "caip19": "eip155:17000/erc20:0x873Ce69Da09b380d6531aBaD3A86A16950e01Fc8",
           "address": "0x873Ce69Da09b380d6531aBaD3A86A16950e01Fc8",
           "burnable": true,
           "symbol": "ERC20TST",
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
           "type": "fungible",
+          "caip19": "eip155:17000/erc20:0xDDf81Bd7c08ad69D4ed82A2c2E190c65D30cc8bA",
           "address": "0xDDf81Bd7c08ad69D4ed82A2c2E190c65D30cc8bA",
           "symbol": "ERC20LRTest",
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
           "type": "nonfungible",
+          "caip19": "eip155:17000/erc20:0xF8550C42Cbe8040D471cEFAA80f4Eded6Cfb34Ab",
           "address": "0xF8550C42Cbe8040D471cEFAA80f4Eded6Cfb34Ab",
           "symbol": "ERC721TST",
           "decimals": 0
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
+          "sygmaResourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
           "type": "permissionlessGeneric",
+          "caip19": "",
           "address": "",
           "symbol": "eth",
           "decimals": 18


### PR DESCRIPTION
## Details

- Refactored pipeline so it supports both old shared configuration format/files and new v3 format of shared configuration.
- Added v3 JSON schema and CI validation
- Made changes required for v3 SDK :point_down: 
### Changes to the devnet shared configuration
- renamed domain property `id` to `sygmaId`
- renamed resource property `resourceId` to `sygmaResourceId`
- added domain property `caipId` - representing [caip2 compatible](https://chainagnostic.org/CAIPs/caip-2) domain identifier
- added resource property `caip19` - representing [caip19 compatible](https://chainagnostic.org/CAIPs/caip-19) resource identifier