### PR TITLE
chore: remove 0x000...500 resource

### DIFF
--- a/testnet/shared-config-test.json
+++ b/testnet/shared-config-test.json
@@ -93,6 +93,13 @@
           "address": "0xcaad55c60823150566f9e2f6040556dc00a67f5c",
           "symbol": "tTNT",
           "decimals": 18
+        },
+        {
+          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000001000",
+          "type": "fungible",
+          "address": "0xAE3283fb214cDb14884039Df09B7895773e68eFA",
+          "symbol": "PHA",
+          "decimals": 18
         }
       ]
     },

--- a/testnet/shared-config-test.json
+++ b/testnet/shared-config-test.json
@@ -67,13 +67,6 @@
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
-          "type": "permissionlessGeneric",
-          "address": "",
-          "symbol": "eth",
-          "decimals": 18
-        },
-        {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
           "type": "permissionlessGeneric",
           "address": "",
@@ -232,13 +225,6 @@
           "decimals": 18
         },
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
-          "type": "permissionlessGeneric",
-          "address": "",
-          "symbol": "",
-          "decimals": 18
-        },
-        {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
           "type": "permissionlessGeneric",
           "address": "",
@@ -284,13 +270,6 @@
         }
       ],
       "resources": [
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
-          "type": "permissionlessGeneric",
-          "address": "",
-          "symbol": "",
-          "decimals": 0
-        },
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
           "type": "permissionlessGeneric",
@@ -345,13 +324,6 @@
       ],
       "resources": [
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
-          "type": "permissionlessGeneric",
-          "address": "",
-          "symbol": "",
-          "decimals": 0
-        },
-        {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
           "type": "permissionlessGeneric",
           "address": "",
@@ -398,13 +370,6 @@
       ],
       "resources": [
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
-          "type": "permissionlessGeneric",
-          "address": "",
-          "symbol": "",
-          "decimals": 0
-        },
-        {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
           "type": "permissionlessGeneric",
           "address": "",
@@ -450,13 +415,6 @@
         }
       ],
       "resources": [
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
-          "type": "permissionlessGeneric",
-          "address": "",
-          "symbol": "",
-          "decimals": 18
-        },
         {
           "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
           "type": "permissionlessGeneric",
@@ -659,6 +617,10 @@
         {
           "type": "permissionlessGeneric",
           "address": "0x39D1Aea5F01138940F19A15049E2073D4df1dc9E"
+        },
+        {
+          "type": "permissionlessGeneric",
+          "address": "0x41f7869e4e0dd06c0c02804e4afcfa76bee92cc7"
         }
       ],
       "nativeTokenSymbol": "ETH",
@@ -679,7 +641,7 @@
       ],
       "resources": [
         {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000500",
+          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
           "type": "permissionlessGeneric",
           "address": "",
           "symbol": "eth",


### PR DESCRIPTION
### Description

- remove 0x000...500 resource
- add gmp handler on b3-sepolia with higher max_fee (for resourceID 0x000...600)
- add PHA token to sepolia