### PR TITLE
chore: add new erc20 and fee handler on devnet

### DIFF
--- a/testnet/shared-config-dev.json
+++ b/testnet/shared-config-dev.json
@@ -13,6 +13,10 @@
           "address": "0x9354dD909416Be9405F174A9Fa81dD5D3F72bE5D"
         },
         {
+          "type":"erc20",
+          "address": "0xb9E2Ef56994D3FCeE782D89f8654e8916803A70e"
+        },
+        {
           "type": "erc721",
           "address": "0x482BBD2DA050dB6f2f6EAa9278408A116905826F"
         },
@@ -29,6 +33,10 @@
         },
         {
           "address": "0x8322A43cBaabfc05A779Bec8f3e05Bd40B0a0a4a",
+          "type": "twap"
+        },
+        {
+          "address": "0x8Fd0b1306eF568Da1f2231F5C54373162cDa5C8d",
           "type": "twap"
         }
       ],
@@ -61,6 +69,14 @@
           "address": "",
           "symbol": "eth",
           "decimals": 18
+        },
+        {
+          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000001200",
+          "caip19": "eip155:11155111/erc20:0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+          "type": "fungible",
+          "address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+          "symbol": "USDC",
+          "decimals": 6
         }
       ]
     },

--- a/testnet/shared-config-dev.json
+++ b/testnet/shared-config-dev.json
@@ -99,6 +99,10 @@
         {
           "type": "permissionlessGeneric",
           "address": "0x675F2F8B8b67149BDac736c1AbD561Ee450a08D5"
+        },
+        {
+          "type": "erc20",
+          "address": "0x62c75f2303A72ABf3978BecEaa79dA029A73C7A6"
         }
       ],
       "feeRouter": "0x3B50efbeadE66cB9Ec1357bafa285608AC2ad996",
@@ -109,6 +113,10 @@
         },
         {
           "address": "0x5B601d41F4db89d39E7004AEfF49533DaA288F3e",
+          "type": "twap"
+        },
+        {
+          "address": "0x15ABB32eC1372896EDC2669cfc92B1ddF37AA75e",
           "type": "twap"
         }
       ],


### PR DESCRIPTION
## Sepolia

- [New ERC20 Handler](https://sepolia.etherscan.io/address/0xb9E2Ef56994D3FCeE782D89f8654e8916803A70e#code)
- [New TWAP ERC20 Fee Handler](https://sepolia.etherscan.io/address/0x8Fd0b1306eF568Da1f2231F5C54373162cDa5C8d)
- [DefaultMessageReceiver](https://sepolia.etherscan.io/address/0x5246ecf1391df5d20d7d3eF468e6f2AB4C5c37B0)
- [TwapOracle](0x4307C1433b61147088fA34184e16802a0F9497b2)

### USDC
- [Register ERC20 handler TX](https://sepolia.etherscan.io/tx/0x926acf4c3d802b086ad536b8c6dd4705db521111543b6ed8fc4c0f9943dc7135)
- [Register fee handler -> Holesky](https://sepolia.etherscan.io/tx/0x2135448c067e9101335559bbb985318d71369c273b85888f0fad747faeaadaba)

### TWAP Fee Handler
- [Set gas price on fee handler -> Holesky](https://sepolia.etherscan.io/tx/0x8b12528efe5d068a4991c3e4d46d8e55800b8ac99257a0bf15dcdb98b8564850)
  - gas price: `1000000000` (1gwei)
  - fee type: `1` (fixed)
  - fee amount: `10000000000000` (0.00001 ETH)
- [Set gas used on fee handler](https://sepolia.etherscan.io/tx/0x8f392891eac896d584d314e02ca638464de0bdfb03878885ce6afff2fec8e378)
- [Set fee oracle](https://sepolia.etherscan.io/tx/0xc2ef1823343843f44eb3dc520f33d64638e4b1cd7b8e0670716b638b2865649f)
- [Set wrapped token](https://sepolia.etherscan.io/tx/0xe8875024370a12fc5b416f22e3c0a52f02e027d5f5788b3dfe4d7811b53d44c2)

### TWAP Oracle
- [Set Price](https://sepolia.etherscan.io/tx/0xb11f741da8e5139b42861433474f2ba22cec31b6364b909432ea8bc4544e471f)

---

## Holesky

For simplicity, register only a new ERC20Handler for execution and map it to the `ERC20LRTest` token, as there is no official USDC deployment on Holesky.

- [New ERC20 Handler](https://holesky.etherscan.io/address/0x62c75f2303A72ABf3978BecEaa79dA029A73C7A6#code)
- [New TWAP ERC20 Fee Handler](https://holesky.etherscan.io/address/0x15ABB32eC1372896EDC2669cfc92B1ddF37AA75e#code)
- [DefaultMessageReceiver](https://holesky.etherscan.io/address/0x8fb9059cBCba31b927dD51124a6C1a7D9ca98eC6#code)
- [TwapOracle](https://holesky.etherscan.io/address/0x4a9cc4161e2D4B3A1f87D1fa0A2F639911C29EB8#code)

### ERC20LRTest
- [Register ERC20 handler TX](https://holesky.etherscan.io/tx/0x740579a56efb78cd9112627ca18192136fefbea6ecbd5ba9ed04d5448118844b)
- ~[Register fee handler -> Sepolia]()~

### TWAP Fee Handler
- ~[Set gas price on fee handler -> Sepolia]()~
- ~[Set gas used on fee handler]()~
- ~[Set fee oracle]()~
- ~[Set wrapped token]()~

### TWAP Oracle
- ~[Set Price]()~
---