### PR TITLE
chore: testnet cleanup

### DIFF
--- a/testnet/balance-config-test.json
+++ b/testnet/balance-config-test.json
@@ -159,121 +159,6 @@
     ]
   },
   {
-    "id": "5",
-    "type": "evm",
-    "balanceData": [
-      {
-        "address": "0xEd4Ee0cF70423A2E4CD3ca960a1932c2D610BB54",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0x0d58d2D2134C99CEac9934524633f02E282dB28C",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0xC567612F0DAc053BdD35FE2363b4193a9B9c31E1",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0xcBE812d1cE78a5FE403757Df45AdC7f59585De7a",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0x4C2A3a361030dC5786b633bc60e6012279aD7316",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0x1690A20A0afF150C0501919604bf46A9C76A1CBd",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0xA6F853fBb6d06Ec88763f0e5cC93132e5329190c",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0x51cD3Fd2f116a87deB330fDf6395326b2e57C629",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0x79Eb01d29e92f62aD49Aa3f7702cB2952F0123BC",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0x6A80C7c2021c6d33d7d30aB8878AffC6913dd9eC",
-        "topic": "TESTNET-relayer-low-balance",
-        "minBalance": "0.1",
-        "decimals": "18",
-        "type": "native",
-        "erc20Address": "",
-        "msgPath": "../nativeLowBalanceTemplate.ejs"
-
-      },
-      {
-        "address": "0x39D1Aea5F01138940F19A15049E2073D4df1dc9E",
-        "topic": "TESTNET-liquidity-low-balance",
-        "minBalance": "200",
-        "decimals": "18",
-        "type": "erc20",
-        "erc20Address": "0x2938ED97eF9D897Dac7B21c48e045f34a3a02846",
-        "msgPath": "../assetLowBalanceTemplate.ejs"
-      }
-    ]
-  },
-  {
     "id": "6",
     "type": "evm",
     "balanceData": [
@@ -580,7 +465,6 @@
       }
     ]
   },
-
   {
     "id": "10",
     "type": "evm",
@@ -704,7 +588,6 @@
       }
     ]
   },
-
   {
     "id": "11",
     "type": "evm",
@@ -810,7 +693,6 @@
       }
     ]
   },
-
   {
     "id": "15",
     "type": "evm",
@@ -926,6 +808,111 @@
       },
       {
         "address": "0x76779F1C15605d78001a364F6E551e25Bb63b74B",
+        "topic": "TESTNET-native-handler-liquidity-low-balance",
+        "minBalance": "0.5",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      }
+    ]
+  },
+  {
+    "id": "16",
+    "type": "evm",
+    "balanceData": [
+      {
+        "address": "0xEd4Ee0cF70423A2E4CD3ca960a1932c2D610BB54",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0x0d58d2D2134C99CEac9934524633f02E282dB28C",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0xC567612F0DAc053BdD35FE2363b4193a9B9c31E1",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0xcBE812d1cE78a5FE403757Df45AdC7f59585De7a",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0x4C2A3a361030dC5786b633bc60e6012279aD7316",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0x1690A20A0afF150C0501919604bf46A9C76A1CBd",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0xA6F853fBb6d06Ec88763f0e5cC93132e5329190c",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0x51cD3Fd2f116a87deB330fDf6395326b2e57C629",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0x79Eb01d29e92f62aD49Aa3f7702cB2952F0123BC",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0x6A80C7c2021c6d33d7d30aB8878AffC6913dd9eC",
+        "topic": "TESTNET-relayer-low-balance",
+        "minBalance": "0.1",
+        "decimals": "18",
+        "type": "native",
+        "erc20Address": "",
+        "msgPath": "../nativeLowBalanceTemplate.ejs"
+      },
+      {
+        "address": "0x579E3e2b73fD14b240a08fdcC50E1e6286c4CB9c",
         "topic": "TESTNET-native-handler-liquidity-low-balance",
         "minBalance": "0.5",
         "decimals": "18",

--- a/testnet/shared-config-test.json
+++ b/testnet/shared-config-test.json
@@ -42,6 +42,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
+      "blockInterval": 10,
       "startBlock": 5703542,
       "feeRouter": "0xD277478b4684Ed8594d5eb5B228AA7aDbA59df43",
       "feeHandlers": [
@@ -158,86 +159,6 @@
       ]
     },
     {
-      "id": 5,
-      "chainId": 338,
-      "caipId": "eip155:338",
-      "name": "cronos",
-      "type": "evm",
-      "bridge": "0x816bb9E810b6b97840F6818bF21Fa25DD7364132",
-      "handlers": [
-        {
-          "type": "erc20",
-          "address": "0x39D1Aea5F01138940F19A15049E2073D4df1dc9E"
-        },
-        {
-          "type": "erc721",
-          "address": "0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a"
-        },
-        {
-          "type": "erc1155",
-          "address": "0x2d92a0aa3Ea19DA735514Ea542438345EF09cB60"
-        },
-        {
-          "type": "permissionlessGeneric",
-          "address": "0x3CBbC542d10CD037cafb1632B29B5B0F59B08A48"
-        },
-        {
-          "type": "permissionlessGeneric",
-          "address": "0x65903772866E538E6fFc001dD0C7665E356eB6d8"
-        }
-      ],
-      "nativeTokenSymbol": "eth",
-      "nativeTokenFullName": "ether",
-      "nativeTokenDecimals": 18,
-      "blockConfirmations": 5,
-      "startBlock": 20483766,
-      "feeRouter": "0xFaa9214b2bb90222c4f5A2DAbBB61fC945CDFD42",
-      "feeHandlers": [
-        {
-          "address": "0x1afc317C3C8578274B557a022aD79e073ef6EBF7",
-          "type": "basic"
-        },
-        {
-          "address": "0xC5244700904c987E5441F568440ed5c3b7233559",
-          "type": "percentage"
-        }
-      ],
-      "resources": [
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000200",
-          "caip19": "eip155:338/erc721:0x18A8E0748FA207483D23aeAc3D0508a25dDA3dB1",
-          "type": "nonfungible",
-          "address": "0x18A8E0748FA207483D23aeAc3D0508a25dDA3dB1",
-          "symbol": "ERC721TST",
-          "decimals": 0
-        },
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000300",
-          "caip19": "eip155:338/erc20:0x2938ED97eF9D897Dac7B21c48e045f34a3a02846",
-          "type": "fungible",
-          "address": "0x2938ED97eF9D897Dac7B21c48e045f34a3a02846",
-          "symbol": "ERC20LRTest",
-          "decimals": 18
-        },
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000400",
-          "caip19": "eip155:338/erc1155:0x0d3Ce33038a3E9bF940eCA6f5EADF355d47D36B3",
-          "type": "semifungible",
-          "address": "0x0d3Ce33038a3E9bF940eCA6f5EADF355d47D36B3",
-          "symbol": "ERC1155TST",
-          "decimals": 18
-        },
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000000600",
-          "caip19": "",
-          "type": "permissionlessGeneric",
-          "address": "",
-          "symbol": "eth",
-          "decimals": 18
-        }
-      ]
-    },
-    {
       "id": 6,
       "chainId": 17000,
       "caipId": "eip155:17000",
@@ -262,6 +183,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
+      "blockInterval": "10",
       "startBlock": 1351739,
       "feeRouter": "0xfc8fE2bC5C780ef8cA28dda09751ef69BdDA53Cb",
       "feeHandlers": [
@@ -318,6 +240,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
+      "blockInterval": 100,
       "startBlock": 33918637,
       "feeRouter": "0x2CD3f725BF9aa446FBD38e2A1A4787a40eEA2286",
       "feeHandlers": [
@@ -366,6 +289,7 @@
       "nativeTokenFullName": "xdai",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
+      "blockInterval": 25,
       "startBlock": 9275873,
       "feeRouter": "0x36930B9117713EF92E2f5Ca4FCa047DAdb92C48E",
       "feeHandlers": [
@@ -396,6 +320,7 @@
       "name": "base_sepolia",
       "type": "evm",
       "bridge": "0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F",
+      "blockInterval": 50,
       "nativeTokenAdapter": "0x6b3BB80A93087CF0eABb72c6a1654C979586E15B",
       "handlers": [
         {
@@ -511,6 +436,7 @@
       "nativeTokenFullName": "matic",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
+      "blockInterval": "50",
       "startBlock":  6042982,
       "feeRouter": "0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6",
       "feeHandlers": [
@@ -539,110 +465,6 @@
           "address": "0x245466D2175bcED0A1ad1ce804C8F724D7050e85",
           "symbol": "ERC20LRTest",
           "decimals": 18
-        }
-      ]
-    },
-    {
-      "id": 12,
-      "chainId": 3799,
-      "caipId": "polkadot:3799",
-      "name": "tangle-standalone-testnet",
-      "type": "substrate",
-      "bridge": "",
-      "handlers": [
-        {
-          "address": "5EYCAe5jLbHcAAMKvLFSXgCTbPrLgBJusvPwfKcaKzuf5X5e",
-          "type": "erc20"
-        },
-        {
-          "address": "5EYCAe5jLbHcAAMKvLFiGhk3htXY8jQncbLTDGJQnpnPMAVp",
-          "type": "erc20"
-        }
-      ],
-      "nativeTokenSymbol": "tTNT",
-      "nativeTokenFullName": "tTNT",
-      "nativeTokenDecimals": 18,
-      "blockConfirmations": 2,
-      "startBlock": 20219,
-      "resources": [
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000002000",
-          "caip19": "polkadot:3799",
-          "type": "fungible",
-          "native": true,
-          "symbol": "tTNT",
-          "decimals": 18,
-          "assetName": "tTNT",
-          "xcmMultiAssetId": {
-            "concrete": {
-              "parents": 0,
-              "interior": "here"
-            }
-          }
-        },
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000001100",
-          "caip19": "polkadot:3799",
-          "type": "fungible",
-          "assetID": 2000,
-          "native": false,
-          "symbol": "sygUSD",
-          "decimals": 6,
-          "assetName": "SygmaUSD",
-          "xcmMultiAssetId": {
-            "parents": 1,
-            "interior": {
-              "X3": [
-                {
-                  "Parachain": 1000
-                },
-                {
-                  "GeneralKey": {
-                    "length": 5,
-                    "data": "0x7379676d61000000000000000000000000000000000000000000000000000000"
-                  }
-                },
-                {
-                  "GeneralKey": {
-                    "length": 6,
-                    "data": "0x7379677573640000000000000000000000000000000000000000000000000000"
-                  }
-                }
-              ]
-            }
-          }
-        },
-        {
-          "resourceId": "0x0000000000000000000000000000000000000000000000000000000000001000",
-          "caip19": "polkadot:3799",
-          "type": "fungible",
-          "assetID": 2001,
-          "native": false,
-          "symbol": "PHA",
-          "decimals": 12,
-          "assetName": "Phala",
-          "xcmMultiAssetId": {
-            "parents": 1,
-            "interior": {
-              "X3": [
-                {
-                  "Parachain": 2004
-                },
-                {
-                  "GeneralKey": {
-                    "length": 5,
-                    "data": "0x7379676d61000000000000000000000000000000000000000000000000000000"
-                  }
-                },
-                {
-                  "GeneralKey": {
-                    "length": 3,
-                    "data": "0x7068610000000000000000000000000000000000000000000000000000000000"
-                  }
-                }
-              ]
-            }
-          }
         }
       ]
     },
@@ -706,6 +528,7 @@
       "nativeTokenFullName": "eth",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
+      "blockInterval": 10,
       "startBlock":  4000715,
       "feeRouter": "0xA56419ECdb71acE442a6FbfC8E50c5F993667938",
       "feeHandlers": [

--- a/testnet/shared-config-test.json
+++ b/testnet/shared-config-test.json
@@ -10,11 +10,11 @@
       "nativeTokenAdapter": "0xb55D0F87eE4a76fAa2f1d01A5abf3f1EB1bbFdd6",
       "handlers": [
         {
-          "type": "erc20", 
+          "type": "erc20",
           "address": "0x0d4fB069753bdf1C5aB48302e9744BF222A9F4e8"
         },
         {
-          "type": "erc20", 
+          "type": "erc20",
           "address": "0xa65387feCb172ffF8A0aabA323A10c63757BBFA6"
         },
         {
@@ -56,15 +56,15 @@
         },
         {
           "address": "0x6a5c39db255D55F77ccA590418EB4175Ec02Ea37",
-          "type": "twap" 
+          "type": "twap"
         },
         {
           "address": "0x52C09318436d729c212B582A0b2Aba2952da0a05",
-          "type": "twap" 
+          "type": "twap"
         },
         {
           "address": "0x0e5F28d6874938CF1504Fe65Fa491E1BA7891B6A",
-          "type": "twap" 
+          "type": "twap"
         }
       ],
       "resources": [
@@ -348,7 +348,7 @@
       "nativeTokenFullName": "ether",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
-      "startBlock":  8708492,
+      "startBlock": 8708492,
       "feeRouter": "0x241a1617a0C73373110F868C07e38679B1Ec4950",
       "feeHandlers": [
         {
@@ -437,7 +437,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "blockInterval": "50",
-      "startBlock":  6042982,
+      "startBlock": 6042982,
       "feeRouter": "0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6",
       "feeHandlers": [
         {
@@ -529,7 +529,7 @@
       "nativeTokenDecimals": 18,
       "blockConfirmations": 5,
       "blockInterval": 10,
-      "startBlock":  4000715,
+      "startBlock": 4000715,
       "feeRouter": "0xA56419ECdb71acE442a6FbfC8E50c5F993667938",
       "feeHandlers": [
         {
@@ -585,6 +585,7 @@
       "chainId": 19934,
       "caipId": "eip155:19934",
       "name": "b4-sepolia",
+      "blockInterval": "10",
       "type": "evm",
       "bridge": "0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F",
       "nativeTokenAdapter": "0x90e3B6Ec4587790c709cb17E5dbAff5F9E682Be5",
@@ -606,7 +607,7 @@
       "nativeTokenFullName": "eth",
       "nativeTokenDecimals": 18,
       "blockConfirmations": 1,
-      "startBlock":  750,
+      "startBlock": 750,
       "feeRouter": "0xde937016D67811f08D93ee54093ea686C21d211C",
       "feeHandlers": [
         {


### PR DESCRIPTION
## Updated networks

**sepolia**
block time: 12s | block interval (default 5)
deposit processing time ~1min

**holesky**
block time: 13s | block interval (default 5)
deposit processing time ~1min

**gnosis-chiado**
block time: 5s | block interval 25
deposit procesing time <2min

**base-sepolia**
block time: 2s | block interval 50
deposit processing time <2min

**amoy**
block time: 2s | block interval 50
deposit processing time <2min

**b3**
block time: 1s | block interval 50
deposit processing time ~1min

## Removed networks
- Tangle
- Cronos testnet