### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -14,10 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Upload production topology to DO Spaces
-        uses: shallwefootball/upload-s3-action@v1.3.3
+        uses: shallwefootball/upload-s3-action@4350529f410221787ccf424e50133cbc1b52704e # v1.3.3
         with:
           aws_key_id: ${{ secrets.DO_SPACES_KEY }}
           aws_secret_access_key: ${{ secrets.DO_SPACES_SECRET }}

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Upload production topology to DO Spaces
-        uses: shallwefootball/upload-s3-action@master
+        uses: shallwefootball/upload-s3-action@v1.3.3
         with:
           aws_key_id: ${{ secrets.DO_SPACES_KEY }}
           aws_secret_access_key: ${{ secrets.DO_SPACES_SECRET }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Upload staging topology to DO Spaces
-        uses: shallwefootball/upload-s3-action@master
+        uses: shallwefootball/upload-s3-action@v1.3.3
         with:
           aws_key_id: ${{ secrets.DO_SPACES_KEY }}
           aws_secret_access_key: ${{ secrets.DO_SPACES_SECRET }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -14,10 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Upload staging topology to DO Spaces
-        uses: shallwefootball/upload-s3-action@v1.3.3
+        uses: shallwefootball/upload-s3-action@4350529f410221787ccf424e50133cbc1b52704e # v1.3.3
         with:
           aws_key_id: ${{ secrets.DO_SPACES_KEY }}
           aws_secret_access_key: ${{ secrets.DO_SPACES_SECRET }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Action references to immutable commit SHAs instead of mutable tags
- Prevents supply chain attacks via tag poisoning (e.g. Trivy-style attacks)
- Version comments preserved inline for auditability
- Actions updated to latest versions where applicable

## Format
```yaml
# Before (mutable tag):
uses: actions/checkout@v6.0.2
# After (immutable SHA):
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```

## Test plan
- [ ] Verify CI passes with SHA-pinned actions